### PR TITLE
update dependency on react-tools to 0.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Matt Lorey <mattlorey@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "react-tools": "^0.10.0",
+    "react-tools": "^0.13.0",
     "mkdirp": "^0.5.0"
   },
   "devDependencies": {},


### PR DESCRIPTION
The dependency on react-tools 0.10 gives the error `Uncaught TypeError: Cannot read property '__reactAutoBindMap' of undefined` when used with the latest React (0.13).  Updating react-tools to 0.13 solves the issue for me.

I'm not sure how important compatibility with earlier versions is, but React seems to be moving pretty fast.